### PR TITLE
feat: add Auto-Curator Agent project to Lab 10

### DIFF
--- a/docs/lab10/projects/auto-curator-agent/.claude/skills/awesome-list-format/SKILL.md
+++ b/docs/lab10/projects/auto-curator-agent/.claude/skills/awesome-list-format/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: awesome-list-format
+description: Formatting rules for the awesome-docker-cagent README.md
+---
+
+# Awesome List Formatting Skill
+
+## Section Structure
+
+1. Official Resources
+2. cagent + MCP
+3. cagent + Docker Model Runner
+4. cagent + IDE (ACP)
+5. cagent + RAG
+6. General Resources
+7. GitHub Sample Projects
+8. MCP Servers for cagent
+9. Featured Videos
+
+## Table Formats
+
+- Blogs: `| [Title](URL) | Source | Description |`
+- Projects (official): `| [Name](URL) | Description |`
+- Projects (community): `| [name](URL) | Description | Author |`
+- MCP servers: `| [name](URL) | Description | XXX⭐ |`
+
+## Rules
+1. Add new entries at END of relevant table
+2. Never reorder existing entries
+3. Keep descriptions under 100 chars
+4. No trailing slashes on URLs
+5. Link to repo root, not specific files

--- a/docs/lab10/projects/auto-curator-agent/.claude/skills/link-validation/SKILL.md
+++ b/docs/lab10/projects/auto-curator-agent/.claude/skills/link-validation/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: link-validation
+description: Link validation patterns for the awesome list
+---
+
+# Link Validation Skill
+
+## Check Each URL
+- 200 OK → ✅ Live
+- 301/302 → ⚠️ Update to final URL
+- 403 → ⚠️ May be rate-limited, retry
+- 404 → ❌ Broken, remove or replace
+- 5xx → ⚠️ Temporary, recheck
+
+## GitHub Repo Checks
+1. Repo exists (not 404)
+2. Not archived
+3. Last commit < 6 months
+4. Note star count for MCP entries
+
+## Content Check
+- Must mention "cagent" (not just generic Docker)
+- Not outdated or deprecated
+
+## Report Format
+- ✅ VALID: URL works, content relevant
+- ⚠️ WARNING: Works but may be outdated
+- ❌ BROKEN: Returns error
+- 🚫 REJECTED: Doesn't meet quality standards

--- a/docs/lab10/projects/auto-curator-agent/.claude/skills/resource-discovery/SKILL.md
+++ b/docs/lab10/projects/auto-curator-agent/.claude/skills/resource-discovery/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: resource-discovery
+description: Search strategies for finding new Docker cagent resources
+---
+
+# Resource Discovery Skill
+
+## Search Queries
+
+### Blogs
+- "docker cagent" blog
+- site:dev.to cagent docker
+- site:docker.com/blog cagent
+- "cagent" "multi-agent" tutorial
+
+### GitHub Repos
+- Search: "cagent" in name/description
+- Topic: docker-cagent
+- Filename: cagent.yaml or cagent-*.yaml
+- Filter: pushed last 30 days, has stars
+
+### MCP Servers
+- "mcp-server docker" on GitHub
+- "type: mcp" "ref: docker" in YAML files
+
+## Quality Scoring (1-5)
+- 5: Official Docker content, major publication
+- 4: Known author, active community project
+- 3: Decent blog post, working example
+- 2: Basic content, minimal repo
+- 1: Low quality or not cagent-specific
+
+Only suggest resources scoring 3+.
+
+## Deduplication
+Always read current README.md first and compare URLs.

--- a/docs/lab10/projects/auto-curator-agent/auto-curator-agent.md
+++ b/docs/lab10/projects/auto-curator-agent/auto-curator-agent.md
@@ -1,0 +1,260 @@
+# 🤖 Auto-Curator Agent - Self-Maintaining Awesome List
+
+A multi-agent system built with Docker cagent that **maintains itself** — it discovers new Docker cagent resources, validates links, and submits PRs to keep the [awesome-docker-cagent](https://github.com/collabnix/awesome-docker-cagent) list fresh.
+
+## 🎯 What You'll Learn
+
+1. Build a 4-agent system with specialized roles (Curator, Discoverer, Validator, Publisher)
+2. Configure GitHub Models as a free LLM provider for cagent
+3. Use custom providers via the `providers:` YAML section
+4. Integrate MCP tools (GitHub, DuckDuckGo, Fetch)
+5. Work with cagent skills for domain-specific knowledge
+6. Handle token limits when using free-tier APIs
+
+## 🏗️ Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      CURATOR (Root)                             │
+│                                                                 │
+│  • Coordinates all maintenance tasks                           │
+│  • Formats entries using awesome-list table syntax             │
+│  • Decides what to add, update, or remove                      │
+└─────────────────────┬───────────────────────────────────────────┘
+                      │
+        ┌─────────────┼─────────────┐
+        ▼             ▼             ▼
+┌───────────────┐ ┌───────────┐ ┌───────────┐
+│  DISCOVERER   │ │ VALIDATOR │ │ PUBLISHER  │
+│               │ │           │ │            │
+│ • Web search  │ │ • Check   │ │ • Create   │
+│ • GitHub API  │ │   URLs    │ │   branches │
+│ • Find repos  │ │ • Quality │ │ • Update   │
+│ • Find blogs  │ │   scoring │ │   README   │
+│               │ │ • Freshness│ │ • Open PRs │
+└───────────────┘ └───────────┘ └───────────┘
+      │                 │             │
+      ▼                 ▼             ▼
+┌───────────┐    ┌───────────┐  ┌──────────┐
+│ DuckDuckGo│    │   Fetch   │  │  GitHub  │
+│    MCP    │    │   Tool    │  │   MCP    │
+└───────────┘    └───────────┘  └──────────┘
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- Docker Desktop 4.49+ (includes cagent)
+- GitHub Personal Access Token with `repo` + `models:read` permissions
+
+### Step 1: Set Up Your GitHub Token
+
+Create a fine-grained PAT at [github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens) with:
+
+| Permission | Scope | Why |
+|-----------|-------|-----|
+| `repo` | Repository | Read/write awesome-list repo, create branches and PRs |
+| `models:read` | Account | Access GitHub Models API for LLM inference |
+
+```bash
+export GITHUB_TOKEN=your_github_pat
+```
+
+### Step 2: Clone and Run
+
+```bash
+git clone https://github.com/ajeetraina/docker-workshop
+cd docker-workshop/docs/lab10/projects/auto-curator-agent/
+
+# Run the lite version (recommended for GitHub Models free tier)
+cagent run ./cagent-curator-lite.yaml "Find new cagent blog posts"
+```
+
+## ⚡ Two Configs: Full vs Lite
+
+| | `cagent-curator.yaml` (Full) | `cagent-curator-lite.yaml` (Lite) |
+|---|---|---|
+| **Skills** | ✅ 3 skill files loaded | ❌ Disabled (saves ~2,500 tokens) |
+| **Instructions** | Detailed with examples | Condensed essentials |
+| **Sub-agent model** | gpt-4o (smart) | gpt-4o-mini (fast) |
+| **Token budget** | ~4,500+ tokens overhead | ~1,500 tokens overhead |
+| **Best for** | Paid GitHub Models / other providers | GitHub Models **free tier** |
+
+!!! warning "GitHub Models Free Tier Token Limit"
+    GitHub Models free tier limits gpt-4o to **8,000 input tokens per request**.
+    Skills + detailed instructions + fetched content can easily exceed this.
+    Use the **lite** version unless you have paid GitHub Models or another provider.
+
+## 📋 Usage Examples
+
+### Discover New Resources
+
+```bash
+# Basic discovery
+cagent run ./cagent-curator-lite.yaml "Find new Docker cagent blog posts published this week"
+
+# Specific and targeted (recommended)
+cagent run ./cagent-curator-lite.yaml "Search for blog posts that specifically mention \
+  'cagent' the Docker multi-agent runtime tool. Only include posts that discuss \
+  cagent YAML configs, cagent run commands, or multi-agent orchestration. \
+  Exclude generic Docker or Docker Model Runner posts."
+
+# With deduplication against existing list
+cagent run ./cagent-curator-lite.yaml "Read the current README from \
+  collabnix/awesome-docker-cagent, then search for new blog posts about \
+  Docker cagent that are NOT already in the list."
+```
+
+### Validate Existing Links
+
+```bash
+cagent run ./cagent-curator-lite.yaml "Read the awesome-docker-cagent README \
+  and check all URLs for broken links"
+```
+
+### Submit Updates via PR
+
+```bash
+cagent run ./cagent-curator-lite.yaml "Find new cagent resources, validate them, \
+  and create a PR adding them to the awesome list"
+```
+
+## 🔧 Configuration Deep Dive
+
+### GitHub Models as a Custom Provider
+
+There is **no built-in `github` provider** in cagent. We define one using the `providers:` section:
+
+```yaml
+providers:
+  github:
+    api_type: openai_chatcompletions
+    base_url: https://models.github.ai/inference
+    token_key: GITHUB_TOKEN
+
+models:
+  smart:
+    provider: github
+    model: openai/gpt-4o      # vendor prefix required!
+    max_tokens: 4096
+  fast:
+    provider: github
+    model: openai/gpt-4o-mini
+    max_tokens: 2048
+```
+
+!!! danger "Common Pitfall: Model Name Format"
+    GitHub Models requires the **`openai/` vendor prefix** in model names.
+    Using just `gpt-4o` results in `403 Forbidden: No access to model: /gpt-4o`.
+    Always use `openai/gpt-4o`, `openai/gpt-4o-mini`, etc.
+
+### GitHub Models Free Tier Rate Limits
+
+| Limit | gpt-4o | gpt-4o-mini |
+|-------|--------|-------------|
+| Input tokens/request | 8,000 | 8,000 |
+| Output tokens/request | 4,096 | 4,096 |
+| Requests/minute | 10 | 15 |
+| Requests/day | 50 | 150 |
+
+## 💡 Prompting Tips
+
+The lite config trades detailed skill instructions for token headroom. **Your prompt quality matters more:**
+
+| ❌ Too Vague | ✅ Specific |
+|---|---|
+| `"Find new cagent blog posts"` | `"Search for posts that specifically mention 'cagent' the Docker multi-agent runtime. Exclude generic Docker or DMR posts."` |
+| `"Check links"` | `"Read the awesome-docker-cagent README and check all URLs in the MCP Servers section for broken links"` |
+
+**Key tips:**
+
+- **Say "cagent" explicitly** — helps distinguish from generic Docker content
+- **Mention what to exclude** — "Exclude Docker Model Runner, Claude Code posts"
+- **Ask it to read the README first** — enables deduplication
+- **One task per prompt** — saves tokens within the 8K limit
+
+## 🐛 Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `403 no_access to model: /gpt-4o` | Missing vendor prefix | Use `openai/gpt-4o` not `gpt-4o` |
+| `403 no_access to model: openai/gpt-4o` | Token missing models permission | Add `models:read` to your PAT |
+| `413 Request Entity Too Large` | Input exceeds 8K tokens | Switch to `cagent-curator-lite.yaml` |
+| `429 Too Many Requests` | Rate limit hit | Wait and retry (10 req/min for gpt-4o) |
+| Results include generic Docker posts | Prompt too vague | Be specific — see Prompting Tips above |
+
+## 📦 Skills (Full Version Only)
+
+The full config loads 3 skills from `.claude/skills/`:
+
+| Skill | Purpose |
+|-------|----------|
+| `awesome-list-format` | Table syntax, section structure, categorization rules |
+| `link-validation` | URL checking, GitHub activity monitoring, content freshness |
+| `resource-discovery` | Search strategies, quality scoring, deduplication |
+
+## 🔄 Automation with GitHub Actions
+
+```yaml
+# .github/workflows/curate.yml
+name: Weekly Curation
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am
+  workflow_dispatch:
+
+jobs:
+  curate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/cagent-action@v1
+        with:
+          config: cagent-curator-lite.yaml
+          prompt: "Search for blog posts that specifically mention cagent the Docker multi-agent runtime. Read the current README first to avoid duplicates. Create a PR with any new findings."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## 📦 Push to Docker Hub
+
+```bash
+docker login
+cagent push ./cagent-curator-lite.yaml docker.io/YOUR_USERNAME/awesome-cagent-curator:latest
+```
+
+## 📊 Workshop Flow
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│              AUTO-CURATOR AGENT WORKFLOW                          │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  1. CONFIGURE          2. DISCOVER          3. PUBLISH           │
+│  ───────────          ───────────          ──────────            │
+│                                                                  │
+│  ┌──────────┐        ┌──────────┐        ┌──────────────┐       │
+│  │  GitHub  │        │  Search  │        │   Create PR  │       │
+│  │  Models  │───────▶│  + Check │───────▶│   to Update  │       │
+│  │  + PAT   │        │  + Score │        │  Awesome List│       │
+│  └──────────┘        └──────────┘        └──────────────┘       │
+│       │                   │                     │                │
+│       ▼                   ▼                     ▼                │
+│  Custom provider     DuckDuckGo MCP        GitHub MCP           │
+│  via providers:      + Fetch tool          creates branch       │
+│  section             validates URLs        + opens PR            │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## 🎓 Key Concepts Covered
+
+| Concept | Description |
+|---------|-------------|
+| **Custom Providers** | Defining GitHub Models as an OpenAI-compatible provider via `providers:` |
+| **Token Budgeting** | Managing free-tier API limits with lite vs full configs |
+| **Multi-Agent Coordination** | 4 agents with specialized roles collaborating on a task |
+| **MCP Tools** | GitHub, DuckDuckGo, and Fetch tools via Model Context Protocol |
+| **cagent Skills** | Domain-specific knowledge loaded from `.claude/skills/` |
+| **Vendor Prefixes** | GitHub Models requires `openai/gpt-4o` format |
+| **Self-Maintaining Systems** | Agents that keep a community resource list up to date |

--- a/docs/lab10/projects/auto-curator-agent/cagent-curator-lite.yaml
+++ b/docs/lab10/projects/auto-curator-agent/cagent-curator-lite.yaml
@@ -1,0 +1,123 @@
+#!/usr/bin/env cagent run
+version: "3"
+
+# =============================================================================
+# Awesome Docker cagent - Auto Curator Agent (LITE)
+# =============================================================================
+# Optimized for GitHub Models FREE TIER (8,000 token input limit per request)
+#
+# Key differences from full version:
+#   - Skills DISABLED (saves ~2,500 tokens per request)
+#   - Instructions trimmed (essential rules inlined)
+#   - Uses gpt-4o-mini for sub-agents (better token efficiency)
+#   - max_tokens reduced to stay within limits
+#
+# Usage:
+#   export GITHUB_TOKEN=your_github_pat  # needs repo + models:read
+#   cagent run ./cagent-curator-lite.yaml "Find new cagent blog posts"
+# =============================================================================
+
+providers:
+  github:
+    api_type: openai_chatcompletions
+    base_url: https://models.github.ai/inference
+    token_key: GITHUB_TOKEN
+
+models:
+  smart:
+    provider: github
+    model: openai/gpt-4o
+    max_tokens: 4096
+
+  fast:
+    provider: github
+    model: openai/gpt-4o-mini
+    max_tokens: 2048
+
+agents:
+  # ---------------------------------------------------------------------------
+  # ROOT: Curator Coordinator
+  # ---------------------------------------------------------------------------
+  root:
+    model: smart
+    description: Coordinates maintenance of collabnix/awesome-docker-cagent.
+    instruction: |
+      You curate the awesome-docker-cagent list at github.com/collabnix/awesome-docker-cagent.
+
+      WORKFLOW: discoverer finds resources → validator checks them → you format entries → publisher creates PR.
+
+      TABLE FORMATS (use exactly):
+      - Blogs: | [Title](URL) | Source | Description |
+      - Projects: | [name](URL) | Description | Author |
+      - MCP servers: | [name](URL) | Description | XXX⭐ |
+
+      SECTIONS: Official Resources, cagent+MCP, cagent+DMR, cagent+IDE, cagent+RAG, General Resources, GitHub Sample Projects, MCP Servers, Featured Videos.
+
+      RULES: Only cagent-specific content (not generic Docker). Add entries at END of relevant table. Never reorder existing entries. Quality score 3+/5 only.
+
+    sub_agents: [discoverer, validator, publisher]
+    toolsets:
+      - type: filesystem
+      - type: think
+      - type: mcp
+        ref: docker:github
+
+  # ---------------------------------------------------------------------------
+  # DISCOVERER: Finds new resources
+  # ---------------------------------------------------------------------------
+  discoverer:
+    model: fast
+    description: Searches web and GitHub for new Docker cagent resources.
+    instruction: |
+      Search for new Docker cagent resources. Use these queries:
+      - Blogs: "docker cagent" blog, site:dev.to cagent, site:docker.com/blog cagent
+      - Repos: search GitHub for "cagent" in name/description, topic:docker-cagent
+      - MCP: "mcp-server docker", "type: mcp" in YAML files
+      - Videos: "docker cagent" site:youtube.com
+
+      For each find, report: Title, URL, Source, Description, Suggested section.
+      Check the current README first to avoid duplicates.
+
+    toolsets:
+      - type: mcp
+        ref: docker:duckduckgo
+      - type: fetch
+      - type: mcp
+        ref: docker:github
+
+  # ---------------------------------------------------------------------------
+  # VALIDATOR: Checks links and quality
+  # ---------------------------------------------------------------------------
+  validator:
+    model: fast
+    description: Validates URLs and content quality for the awesome list.
+    instruction: |
+      For each URL: fetch it, verify it loads (200=✅, 404=❌, 301=⚠️ update URL).
+      For GitHub repos: check if archived, check last commit date, note star count.
+      Content must mention "cagent" specifically (not just generic Docker).
+      Report: ✅ VALID, ⚠️ WARNING, ❌ BROKEN, or 🚫 REJECTED with reason.
+
+    toolsets:
+      - type: fetch
+      - type: mcp
+        ref: docker:github
+
+  # ---------------------------------------------------------------------------
+  # PUBLISHER: Creates PRs
+  # ---------------------------------------------------------------------------
+  publisher:
+    model: fast
+    description: Creates branches and PRs to update the awesome list.
+    instruction: |
+      To publish changes to collabnix/awesome-docker-cagent:
+      1. Read current README.md (get its SHA for updates)
+      2. Create branch: curator/add-resources-YYYY-MM-DD
+      3. Update README.md with new entries in correct sections
+      4. Create PR with clear title and change list
+
+      CRITICAL: Add entries at END of tables. Never overwrite existing content.
+      Include file SHA when updating to avoid conflicts.
+
+    toolsets:
+      - type: mcp
+        ref: docker:github

--- a/docs/lab10/projects/auto-curator-agent/cagent-curator.yaml
+++ b/docs/lab10/projects/auto-curator-agent/cagent-curator.yaml
@@ -1,0 +1,151 @@
+#!/usr/bin/env cagent run
+version: "3"
+
+# =============================================================================
+# Awesome Docker cagent - Auto Curator Agent (FULL)
+# =============================================================================
+# Full version with skills enabled. Requires paid GitHub Models or another
+# provider with higher token limits (>8K input tokens per request).
+#
+# For GitHub Models free tier, use cagent-curator-lite.yaml instead.
+#
+# Usage:
+#   export GITHUB_TOKEN=your_github_token
+#   cagent run ./cagent-curator.yaml "Find new cagent blog posts from the last week"
+# =============================================================================
+
+providers:
+  github:
+    api_type: openai_chatcompletions
+    base_url: https://models.github.ai/inference
+    token_key: GITHUB_TOKEN
+
+models:
+  smart:
+    provider: github
+    model: openai/gpt-4o
+    max_tokens: 8192
+
+  fast:
+    provider: github
+    model: openai/gpt-4o-mini
+    max_tokens: 4096
+
+agents:
+  root:
+    model: smart
+    skills: true
+    description: |
+      Coordinates maintenance of the awesome-docker-cagent list at
+      github.com/collabnix/awesome-docker-cagent. Discovers new resources,
+      validates links, and submits PRs.
+    instruction: |
+      You are the curator of the awesome-docker-cagent list, a community-maintained
+      collection of Docker cagent resources hosted at:
+      https://github.com/collabnix/awesome-docker-cagent
+
+      ## Your Responsibilities
+
+      1. **Discover** new cagent resources by delegating to the `discoverer` agent
+      2. **Validate** links and content quality via the `validator` agent
+      3. **Format** entries correctly using the awesome-list-format skill
+      4. **Submit** changes via the `publisher` agent as GitHub PRs
+
+      ## Workflow for Finding New Resources
+
+      1. Delegate to `discoverer` to search for new blogs, repos, videos, MCP servers
+      2. Delegate to `validator` to check each URL is live and content is relevant
+      3. Format validated resources into the correct markdown table format
+      4. Delegate to `publisher` to create a branch and PR with the additions
+
+      ## Quality Standards
+      - Only include resources specifically about Docker cagent (not generic Docker)
+      - Prefer official sources, well-known tech blogs, and active GitHub repos
+      - Exclude paywalled content, spam, or low-quality posts
+      - Repos should have meaningful content (not just a fork or empty README)
+
+      ## Repository Details
+      - Owner: collabnix
+      - Repo: awesome-docker-cagent
+      - Main file: README.md
+      - Default branch: main
+
+    sub_agents: [discoverer, validator, publisher]
+    toolsets:
+      - type: filesystem
+      - type: think
+      - type: todo
+      - type: mcp
+        ref: docker:github
+
+  discoverer:
+    model: smart
+    skills: true
+    description: |
+      Searches the web and GitHub for new Docker cagent resources including
+      blog posts, tutorials, sample projects, MCP servers, and videos.
+    instruction: |
+      You are a research specialist focused on discovering new Docker cagent resources.
+
+      Search for: "docker cagent" blog, cagent multi-agent, cagent MCP,
+      cagent docker model runner, cagent yaml agent.
+
+      Sources: docker.com/blog, dev.to, medium.com, dzone.com, collabnix.com, hashnode.
+
+      For GitHub: search repos with "cagent" in name/description, topic docker-cagent.
+
+      For each resource provide: Title, URL, Source/Author, Description,
+      Suggested category, Why it's worth including.
+
+      Always check against current README.md to avoid duplicates.
+
+    toolsets:
+      - type: mcp
+        ref: docker:duckduckgo
+      - type: fetch
+      - type: filesystem
+      - type: mcp
+        ref: docker:github
+
+  validator:
+    model: fast
+    skills: true
+    description: |
+      Validates URLs, checks content relevance, and ensures resources
+      meet the awesome list quality standards.
+    instruction: |
+      For each URL: fetch and check response (200=✅, 404=❌, 301=⚠️).
+      For GitHub repos: check archived status, last commit date, star count.
+      Content must mention "cagent" specifically (not just generic Docker).
+      Report: ✅ VALID, ⚠️ WARNING, ❌ BROKEN, or 🚫 REJECTED with reason.
+
+    toolsets:
+      - type: filesystem
+      - type: fetch
+      - type: think
+      - type: mcp
+        ref: docker:github
+
+  publisher:
+    model: smart
+    skills: true
+    description: |
+      Creates GitHub branches and pull requests to update the
+      awesome-docker-cagent README.md with new resources.
+    instruction: |
+      Publish changes to collabnix/awesome-docker-cagent via GitHub PRs.
+
+      1. Read current README.md (get its SHA)
+      2. Create branch: curator/add-resources-YYYY-MM-DD
+      3. Update README.md with new entries in correct sections
+      4. Create PR with clear title and change list
+
+      Follow the awesome-list-format skill for table syntax.
+      Add entries at END of relevant tables. Never overwrite existing entries.
+      Include file SHA when updating.
+
+    toolsets:
+      - type: filesystem
+      - type: think
+      - type: mcp
+        ref: docker:github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,8 @@ nav:
            - Docker Expert Team: lab10/projects/docker-expert.md
            - Bug Investigator: 
              - Overview: lab10/projects/bug-investigator/bug-investigator.md
+           - Auto-Curator Agent:
+             - Overview: lab10/projects/auto-curator-agent/auto-curator-agent.md
       - Sharing Agents: lab10/sharing.md
     - Docker Model Runner:
       - Overview: lab4/overview.md


### PR DESCRIPTION
## New Project: Auto-Curator Agent

Adds the auto-curator-agent project to Lab 10 (cagent Projects), following the same structure as bug-investigator.

### Files Added

**Workshop Page:**
- `docs/lab10/projects/auto-curator-agent/auto-curator-agent.md` — Full workshop page with architecture, quick start, config deep dive, prompting tips, troubleshooting, and key concepts

**cagent Configs:**
- `cagent-curator-lite.yaml` — Optimized for GitHub Models free tier (8K token limit)
- `cagent-curator.yaml` — Full version with skills enabled (needs paid tier or other provider)

**Skills (for full version):**
- `.claude/skills/awesome-list-format/SKILL.md`
- `.claude/skills/link-validation/SKILL.md`
- `.claude/skills/resource-discovery/SKILL.md`

**Navigation:**
- Updated `mkdocs.yml` — Added under Multi-agent Systems alongside Bug Investigator

### What This Project Teaches
- Custom providers (GitHub Models via `providers:` section)
- Token budgeting (free tier limits vs full config)
- Multi-agent coordination (4 agents: Curator, Discoverer, Validator, Publisher)
- MCP tools (GitHub, DuckDuckGo, Fetch)
- cagent Skills system
- Vendor prefix gotchas (`openai/gpt-4o` not `gpt-4o`)
- Self-maintaining community resource lists