### PR TITLE
Add Docker Sandbox content from labspace-sbx

### DIFF
--- a/docs/lab8/getting-started.md
+++ b/docs/lab8/getting-started.md
@@ -1,0 +1,244 @@
+# Pre-flight Checklist
+
+Before starting the lab, confirm your environment is ready. Every exercise depends on `sbx` running correctly on your host machine. **Do not skip this section.**
+
+---
+
+## Requirements
+
+| Requirement | Platform |
+|---|---|
+| macOS Apple Silicon (M1/M2/M3/M4) | ✅ Fully supported |
+| Linux x86_64 (Ubuntu 22.04+, KVM access) | ✅ Supported |
+| macOS Intel | ❌ Not supported |
+| Windows 11 x86_64 | ⚠️ Supported, some exercises differ |
+
+---
+
+## Step 1 — Verify sbx is installed
+
+Open a terminal on your host machine and run:
+
+```bash
+sbx version
+```
+
+Expected output: a version string like `sbx 0.21.0` or similar.
+
+If you see `command not found`, install sbx first:
+
+```bash
+# macOS
+brew install docker/tap/sbx
+
+# Linux
+curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+sudo apt-get install docker-sbx
+sudo usermod -aG kvm $USER
+newgrp kvm
+```
+
+---
+
+## Step 2 — Log in to Docker
+
+```bash
+sbx login
+```
+
+The CLI prints a one-time device confirmation code and a URL:
+
+```
+Your one-time device confirmation code: XXXX-XXXX
+Open this URL to sign in: https://login.docker.com/activate?user_code=XXXX-XXXX
+
+By logging in, you agree to our Subscription Service Agreement.
+For more details, see https://www.docker.com/legal/docker-subscription-service-agreement/
+
+Waiting for authentication...
+Signed in as <your-docker-username>.
+Daemon started (PID: XXXXX, socket: ~/Library/Application Support/com.docker.sandboxes/sandboxd/sandboxd.sock)
+Logs: ~/Library/Application Support/com.docker.sandboxes/sandboxd/daemon.log
+```
+
+Open the URL in your browser — the CLI confirms sign-in automatically.
+
+### Choose a network policy
+
+```
+Select a default network policy for your sandboxes:
+
+     1. Open         — All network traffic allowed, no restrictions.
+  ❯  2. Balanced     — Default deny, with common dev sites allowed.
+     3. Locked Down  — All network traffic blocked unless you allow it.
+
+  Use ↑/↓ or 1–3 to navigate, Enter to confirm, Esc to cancel.
+
+Network policy set to "Balanced". Default deny, with common dev sites allowed.
+```
+
+| Policy | When to use |
+|--------|-------------|
+| Open | Local dev, no external exposure concerns |
+| **Balanced** | **Recommended — least privilege without breaking typical dev workflows** |
+| Locked Down | High-security or air-gapped environments |
+
+> **Note:** This policy applies to all sandboxes on this machine. Change it anytime with `sbx policy reset`.
+
+---
+
+## Step 3 — Choose your agent and provider
+
+This lab works with any mainstream coding agent. Pick the provider whose API key you have — the rest of the lab will adapt.
+
+!!! tip "Pick a provider for the rest of this lab"
+    Each option below assumes you've chosen one of these:
+
+    - **Use OpenAI + Codex**
+    - **Use Anthropic + Claude**
+    - **Use Google + Gemini**
+
+&nbsp;
+
+!!! note "If you chose OpenAI + Codex"
+
+    ### OpenAI configuration
+
+    You'll run **Codex** inside the sandbox, authenticated to OpenAI.
+
+    **First, export your API key in your host terminal** (don't paste it into this page):
+
+    ```bash
+    export OPENAI_API_KEY=sk-proj-...    # your real key, set in your own shell
+    ```
+
+    Then store it as a global sbx secret. The command below reads `$OPENAI_API_KEY` from your shell — your key never leaves the terminal and is not displayed anywhere:
+
+    ```bash
+    echo "$OPENAI_API_KEY" | sbx secret set -g openai
+    ```
+
+!!! note "If you chose Anthropic + Claude"
+
+    ### Anthropic configuration
+
+    You'll run **Claude Code** inside the sandbox, authenticated to Anthropic.
+
+    **First, export your API key in your host terminal** (don't paste it into this page):
+
+    ```bash
+    export ANTHROPIC_API_KEY=sk-ant-...    # your real key, set in your own shell
+    ```
+
+    Then store it as a global sbx secret. The command below reads `$ANTHROPIC_API_KEY` from your shell — your key never leaves the terminal and is not displayed anywhere:
+
+    ```bash
+    echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
+    ```
+
+!!! note "If you chose Google + Gemini"
+
+    ### Gemini configuration
+
+    You'll run **Gemini CLI** inside the sandbox, authenticated to Google.
+
+    **First, export your API key in your host terminal** (don't paste it into this page):
+
+    ```bash
+    export GOOGLE_API_KEY=AIza...    # your real key, set in your own shell
+    ```
+
+    Then store it as a global sbx secret. The command below reads `$GOOGLE_API_KEY` from your shell — your key never leaves the terminal and is not displayed anywhere:
+
+    ```bash
+    echo "$GOOGLE_API_KEY" | sbx secret set -g google
+    ```
+
+> **Why not type the key into this page?** Labspace renders anything you enter into an input field inline in the command below it — so the raw key becomes visible in the lab UI and in screenshots. Setting the env var in your own shell keeps the key off the page entirely.
+
+Verify the secret was stored:
+
+```bash
+sbx secret ls
+```
+
+Expected output: a line matching your chosen provider (`openai`, `anthropic`, or `google`) with the value masked as `****...****`.
+
+> **Why this matters:** Secrets are stored in your OS keychain and injected at the network proxy layer. The agent never sees the raw API key. This is one of the core governance guarantees you'll explore in Module 4.
+
+---
+
+## Step 4 — Clone the lab repository
+
+The exercises use DevBoard — a full-stack FastAPI + Next.js issue tracker with intentional bugs. It's pre-configured for this lab.
+
+```bash
+git clone https://github.com/dockersamples/sbx-quickstart ~/sbx-lab
+cd ~/sbx-lab
+```
+
+---
+
+## Step 5 — Create your sandbox
+
+```bash
+cd ~/sbx-lab
+sbx create --name=sbxlab <agent> .
+```
+
+> **First run:** The agent image will pull (1–2 minutes) and the sandbox will be created with the Balanced network policy you selected at login.
+
+```bash
+sbx ls
+```
+
+You should see `sbxlab` in the list with status `stopped`:
+
+```
+SANDBOX   AGENT    STATUS    PORTS   WORKSPACE
+sbxlab    <agent>   stopped           /your/project/path
+```
+
+Once you run it (Step 6), the status changes to `running`.
+
+---
+
+## Step 6 — Run your sandbox
+
+```bash
+sbx run sbxlab
+```
+
+On first run, the agent may auto-update itself. If you see an update message, simply re-run the command:
+
+```bash
+sbx run sbxlab
+```
+
+You will then see a trust prompt before the agent starts:
+
+```
+INFO: Starting Docker daemon
+Starting <agent> agent in sandbox 'sbxlab'...
+Workspace: /your/project/path
+
+> You are in /your/project/path
+
+  Do you trust the contents of this directory? Working with untrusted
+  contents comes with higher risk of prompt injection.
+
+› 1. Yes, continue
+  2. No, quit
+```
+
+Select **1. Yes, continue** to launch the agent.
+
+> **Why this prompt exists:** sbx mounts only your project directory into the microVM. The trust check ensures you're aware of what the agent can see and act on.
+
+---
+
+## ✅ Ready to go
+
+All six steps pass? Move to Module 1.
+
+If anything failed, check [Troubleshooting](https://docs.docker.com/ai/sandboxes/troubleshooting/) or the Appendix at the end of this lab.

--- a/docs/lab8/overview.md
+++ b/docs/lab8/overview.md
@@ -1,0 +1,53 @@
+
+## What is Docker Sandboxes?
+
+[Docker Sandboxes (sbx)](https://github.com/docker/sbx-releases) is a microVM-based runtime for running AI coding agents safely. Instead of letting agents like Claude Code, Codex, or Gemini CLI run as a regular user process on your laptop — with full access to your home directory, SSH keys, AWS credentials, and Docker daemon — sbx runs each agent inside a lightweight virtual machine with its own kernel. Only the workspace directory you explicitly mount is shared. Everything else stays on the host.
+
+The boundary is **structural**, enforced by the hypervisor — not by a permission dialog, a system prompt, or a policy document the agent has agreed to follow.
+
+## What problem it solves?
+
+When a developer runs an AI coding agent on their laptop without sandboxing, the agent runs as their user. That means it has access to everything they have access to:
+
+- `~/.aws/credentials` — AWS access keys
+- `~/.ssh/id_rsa` — SSH private keys
+- `.env` files — database passwords, API tokens
+- The entire home directory
+- Any running Docker containers on the host
+
+The agent isn't malicious. But it doesn't need to be for something to go wrong. A confused agent, a malicious MCP server, or a prompt injection attack can cause the agent to exfiltrate credentials or corrupt data. And without an audit trail, you won't know it happened.
+
+Real incidents in 2025 — leaked system prompts, RCE via malicious MCP file swaps, MCP tool poisoning across Anthropic, OpenAI, Zapier, and Cursor — all share the same pattern: **agents are trusted, and that trust is being exploited.**
+
+The current "solutions" don't hold up:
+
+- **Permission dialogs** get dismissed in YOLO mode and become noise. They're not security.
+- **System prompt instructions** are just text. They can be overridden by prompt injection and have no enforcement mechanism.
+
+## The Solution
+
+Docker Sandboxes wraps each agent in a microVM with four layers of governance built in:
+
+- **Structural Isolation**: The agent runs inside a VM with its own Linux kernel. Host credentials, SSH keys, and the host Docker socket are simply not present inside the VM. There is nothing to exfiltrate.
+- **Credential Proxy Injection**: API keys live in your OS keychain. When the agent makes an outbound request, a host-side proxy intercepts it and injects the auth header. The raw key never enters the VM.
+- **Network Policy Enforcement**: Every outbound connection passes through a policy layer (Open / Balanced / Locked Down). Allowed and blocked attempts are logged in real time.
+- **Branch Mode and Parallel Execution**: Agents work on isolated Git worktrees so you can review diffs before merging — and run multiple agents on the same repo simultaneously without conflicts.
+
+This is the infrastructure that makes semi-autonomous and autonomous agent workflows safe to operate.
+
+## Key Features
+
+- microVM Isolation: Each sandbox is a lightweight VM with its own kernel. The boundary is enforced by the hypervisor, not by a policy file.
+- Credential Proxy: API keys stay on the host. Authentication happens at the proxy layer so the agent never sees the raw key.
+- Network Policy: Pick Open, Balanced, or Locked Down at login. Override per-sandbox. Watch every connection in a live audit log.
+- Branch Mode: Agent work lands on its own Git worktree and branch. Review the diff, then merge — or throw it away.
+- Parallel Agents: Run multiple agents on the same codebase at once. Each gets its own worktree. No file-locking, no conflicts.
+- Local Model Support: Run open-source models inside sbx via Docker Model Runner. Zero cloud egress, zero API keys, fully air-gapped workflows.
+- Pluggable Agents: Works with Codex, Claude Code, Gemini CLI, and any agent image you publish.
+
+# Who's This For
+
+- Developers Running Coding Agents: Run Claude Code, Codex, or Gemini CLI without giving them access to your SSH keys, AWS credentials, or host Docker daemon.
+- Platform Engineers: Provide a paved path for agent execution across the org. Centralized network policy, centralized secret management, audit logs by default.
+- Security Teams: Get the structural guarantees and the audit trail you need to sign off on agentic workloads — without blocking developer productivity.
+- Enterprises Operating at Scale: The architecture that makes 30,000 concurrent governed agent sessions across a workforce a tractable problem rather than an unbounded risk.

--- a/docs/lab8/projects/branch-mode.md
+++ b/docs/lab8/projects/branch-mode.md
@@ -1,0 +1,143 @@
+# Branch Mode — Agent on Its Own Worktree
+
+So far the agent has been editing files directly in your workspace. That's **direct mode** — fast, visible, bidirectional. Good for interactive work.
+
+**Branch mode** is different. The agent gets its own Git worktree and branch, isolated from your main working tree. You keep working normally. The agent works on its branch. You review the diff and decide whether to merge.
+
+---
+
+## When to use branch mode
+
+| Direct Mode | Branch Mode |
+|---|---|
+| Interactive back-and-forth | Longer autonomous runs |
+| Quick edits you want immediately | Changes you want to review before merging |
+| Exploratory work | Production-ready feature work |
+| Single agent | Multiple parallel agents |
+
+---
+
+## Exit your current session first
+
+Press **Ctrl-C twice** to exit the agent session and return to your host terminal.
+
+---
+
+## Start a branch mode session
+
+```bash
+sbx run sbxlab --branch=fix-bugs
+```
+
+sbx creates a Git worktree at `.sbx/sbxlab-worktrees/fix-bugs` in your repo root. The agent works on its own branch and directory without touching your main working tree.
+
+---
+
+## Give the agent a real task
+
+Inside the sandbox, give it this prompt:
+
+```
+Run the test suite for the FastAPI backend. Find the failing tests.
+Fix the pagination bug in backend/app/main.py. Commit with a descriptive message.
+
+Use: cd backend && pytest tests/ -v
+```
+
+The agent will take 3–5 minutes to run tests, diagnose failures, fix the bug, and commit.
+
+---
+
+## Monitor without interrupting
+
+While the agent works, open a **second host terminal** and watch the worktree:
+
+```bash
+cd ~/sbx-lab
+
+# See the worktree
+ls .sbx/
+
+# See all worktrees
+git worktree list
+
+# Watch commits appear in real time
+git log --oneline fix-bugs
+```
+
+You can see exactly what the agent is doing without interrupting the session.
+
+---
+
+## Review the changes
+
+When the agent is done, exit the session (Ctrl-C twice) and review:
+
+```bash
+# See the full diff
+git diff main..fix-bugs
+
+# Or just the changed files
+git diff main..fix-bugs --name-only
+```
+
+The diff is clean. The agent worked on its branch. Your `main` is untouched.
+
+---
+
+## Push and open a PR
+
+If you're happy with the changes:
+
+```bash
+git push origin fix-bugs
+
+gh pr create \
+  --head fix-bugs \
+  --title "Fix: pagination offset bug" \
+  --body "Fixes off-by-one error in list_issues() pagination"
+```
+
+This is the same PR workflow your team already uses — just with the agent as the author.
+
+---
+
+## Auto-naming branches
+
+You don't have to name the branch yourself:
+
+```bash
+sbx run sbxlab --branch auto
+```
+
+sbx generates a name. Useful when you just want isolation without thinking about naming.
+
+---
+
+## The worktree directory
+
+```bash
+ls .sbx/
+# sbxlab-worktrees/
+#   fix-bugs/    ← the agent worked here
+```
+
+The worktree is a real Git worktree. It has the full repo history. It shares objects with your main clone (no duplication). When you delete the sandbox:
+
+```bash
+sbx rm sbxlab
+```
+
+The VM is deleted along with all its worktrees under `.sbx/`. Your source files in `~/sbx-lab` are untouched.
+
+---
+
+## ✅ Checkpoint
+
+Confirm:
+- `sbx run sbxlab --branch=fix-bugs` created a worktree at `.sbx/sbxlab-worktrees/fix-bugs`
+- `git diff main..fix-bugs` shows the agent's changes
+- Your `main` branch is unchanged
+- `git worktree list` shows both branches
+
+Next: running multiple agents in parallel — without conflicts.

--- a/docs/lab8/projects/first-sandbox.md
+++ b/docs/lab8/projects/first-sandbox.md
@@ -1,0 +1,146 @@
+# Your First Sandbox
+
+Time to get hands-on. In this module you'll start your sandbox, explore the architecture from inside and outside the VM, and get your agent running.
+
+---
+
+## Start the sandbox
+
+From your host terminal, in `~/sbx-lab`:
+
+```bash
+sbx run sbxlab
+```
+
+On first run, the agent may auto-update itself:
+
+!!! note "If you chose OpenAI + Codex"
+
+    ```
+    Starting codex agent in sandbox 'sbxlab'...
+    Workspace: /your/project/path
+
+    Updating Codex via `npm install -g @openai/codex`...
+
+    changed 2 packages in 4s
+
+    🎉 Update ran successfully! Please restart Codex.
+    ```
+
+!!! note "If you chose Anthropic + Claude"
+
+    ```
+    Starting claude agent in sandbox 'sbxlab'...
+    Workspace: /your/project/path
+
+    Updating Claude Code via `npm install -g @anthropic-ai/claude-code`...
+
+    changed 2 packages in 4s
+
+    🎉 Update ran successfully! Please restart Claude Code.
+    ```
+
+!!! note "If you chose Google + Gemini"
+
+    ```
+    Starting gemini agent in sandbox 'sbxlab'...
+    Workspace: /your/project/path
+
+    Updating Gemini CLI...
+    ```
+
+If you see an update message, re-run `sbx run sbxlab`. You will then see the trust prompt:
+
+```
+  Do you trust the contents of this directory? Working with untrusted
+  contents comes with higher risk of prompt injection.
+
+› 1. Yes, continue
+  2. No, quit
+```
+
+Select **1. Yes, continue**.
+
+---
+
+## Explore the codebase
+
+Once the agent is running, give it this prompt:
+
+```
+Explore this codebase and give me:
+1. A summary of the architecture and tech stack
+2. How to run it locally without Docker Compose
+3. What the test suite covers
+4. Any obvious issues or areas of concern
+```
+
+The agent will read the source files and report back. Watch it work — it's reading the actual files from your `~/sbx-lab` directory.
+
+---
+
+## What's happening under the hood
+
+While the agent is working, open a **second terminal on your host** and run:
+
+```bash
+# These show the sandbox is a VM, not a container
+docker ps          # sbxlab does NOT appear here
+sbx ls             # sbxlab appears HERE instead
+```
+
+Expected output from `sbx ls`:
+
+```
+SANDBOX   AGENT      STATUS    PORTS   WORKSPACE
+sbxlab    <agent>   running           /your/project/path
+```
+
+The sandbox isn't a container on your host — it's a VM. That distinction matters, and you'll prove it hands-on in the next module.
+
+---
+
+## Understanding the workspace mount
+
+Your `~/sbx-lab` directory is mounted into the VM at the same absolute path. This means:
+
+- **Changes you make on the host** appear instantly inside the sandbox
+- **Changes the agent makes inside the sandbox** appear instantly on your host
+- **Nothing else from your host** is accessible inside the VM
+
+Open one of the source files in your editor on the host. Make a small change and save it. Then ask the agent inside the sandbox to read that file. It sees your change immediately — no sync delay, no copy step.
+
+---
+
+## Controlling the session
+
+| Action | Command |
+|---|---|
+| Exit the agent session | Press `Ctrl-C` twice |
+| Open the interactive dashboard | Run `sbx` with no arguments (new terminal) |
+
+---
+
+## The interactive TUI dashboard
+
+In a separate host terminal, run:
+
+```bash
+sbx
+```
+
+The dashboard shows your sandboxes as cards with live CPU and memory usage. Press `Tab` to switch to the **Network panel** — a live log of every outbound connection the sandbox makes.
+
+Press `Ctrl-C` then `Y` to exit without stopping your sandboxes.
+
+---
+
+## ✅ Checkpoint
+
+Before moving on, confirm:
+- `sbx run sbxlab` worked and the agent responded
+- `docker ps` on the host shows no sandbox
+- `sbx ls` on the host shows `sbxlab` with status `running`
+- The agent can read the codebase files
+
+Next: the isolation proof — where you'll systematically try to break out of the VM.

--- a/docs/lab8/projects/governance-summary.md
+++ b/docs/lab8/projects/governance-summary.md
@@ -1,0 +1,129 @@
+# AI Governance at Enterprise Scale
+
+You've run through every major capability of Docker Sandboxes. Now let's connect what you learned to the bigger picture — and to your own team.
+
+---
+
+## What you proved in this lab
+
+Go back to your reflection from Module 3. You wrote down what specific resources were not accessible from inside the sandbox. Everything you listed there is what governance protects.
+
+Here's what you demonstrated hands-on:
+
+| Governance Capability | How You Proved It |
+|---|---|
+| **Structural isolation** | Tried to access `~/.aws/credentials` and `~/.ssh/id_rsa` — not there |
+| **Credential proxy injection** | Asked the agent to print its API key — it couldn't |
+| **Network enforcement** | Blocked PyPI, saw the install fail in real time |
+| **Audit trail** | Watched `sbx policy log` show every connection |
+| **Safe review workflow** | Used branch mode to get a clean diff before merging |
+| **Scale** | Ran two agents in parallel, zero conflicts |
+| **Local inference** | Ran Docker Model Runner on the host, agent in the VM, zero cloud dependency |
+
+None of these relied on a policy document. None relied on a system prompt instruction. All of them are structural.
+
+---
+
+## The four enterprise requirements — answered
+
+If you were presenting this to a risk team, here's how each requirement maps:
+
+**1. Sandbox isolation (structural, not advisory)**
+MicroVM boundary. Agent runs inside its own kernel. Host credentials don't exist inside the VM. Verified by you in Module 3.
+
+**2. BYOLLM / LLM Gateway**
+Secrets are stored in the OS keychain, injected at the proxy layer. All LLM traffic routes through the host-side proxy. The gateway is the proxy. Verified in Module 4. For air-gapped deployments, local models via Docker Model Runner give you the same architecture with zero cloud dependency.
+
+**3. Telemetry and audit logging**
+`sbx policy log` shows every outbound connection — allowed or blocked — with timestamps and agent attribution. Verified in Module 5.
+
+**4. Container customisation**
+Custom templates let you pre-bake certs, proxy settings, toolchains into the sandbox image. The same policy applies whether agents run on a developer laptop, in CI, or in the cloud.
+
+---
+
+## The autonomy scale — where does your team sit?
+
+| Stage | Name | Description | Governance needed |
+|---|---|---|---|
+| 1 | Autocomplete | Code suggestions | None |
+| 2 | Assistant | Chat, explanations | None |
+| 3 | Specialist | Multi-step tasks | Recommended |
+| **4** | **Semi-Autonomous** | **Agent loops** | **Required** |
+| **5** | **Autonomous** | **Self-directed** | **Required** |
+| 6 | Steward | Long-term trust | Required + audit |
+
+Most teams today are at stage 2–3. The question isn't whether they'll move to 4–5 — agents will get more capable, and developers will use them more autonomously. The question is whether governance is in place before that happens.
+
+---
+
+## Your reflection
+
+Answer these questions before finishing the lab:
+
+> **1.** Before this lab, how did your team run AI coding agents? Were any governance controls in place?
+>
+> **2.** What specific risks does your codebase have that an ungoverned agent could trigger? (Think: credentials, production configs, sensitive data files)
+>
+> **3.** Which of the four governance capabilities would be hardest to add after the fact, once agents are already widely deployed?
+>
+> **4.** What would a 20-developer pilot look like for your team? What would "success" mean after 2 weeks?
+
+---
+
+## What's next
+
+**For individuals:**
+- Read the [sbx documentation](https://docs.docker.com/ai/sandboxes/)
+- Try the [sbx-quickstart](https://github.com/dockersamples/sbx-quickstart) with your own codebase
+- Explore custom templates for your stack
+
+**For teams:**
+- Map your team's current agent usage (who's using what, with what access)
+- Identify the highest-risk credential exposure scenarios
+- Define your network policy — start with Balanced, move to Locked Down for production use
+- Set up branch mode as the default for autonomous agent runs
+
+**For enterprises:**
+- The admin console provides org-wide policy configuration
+- Pilot with 20–30 developers, 2 weeks, defined success criteria
+- Audit log integration with your SIEM
+- Docker Hardened Images as the sandbox base image for minimal attack surface
+
+---
+
+## CLI Reference
+
+```bash
+# Lifecycle
+sbx create --name=X <agent> .        # create sandbox with your chosen agent
+sbx run X                              # attach to sandbox
+sbx run X --branch=NAME                # branch mode
+sbx ls                                 # list sandboxes
+sbx stop X / sbx rm X                  # pause / delete
+
+# Inspection
+sbx exec -it X bash                    # shell inside sandbox
+sbx ports X --publish H:S              # port forwarding
+
+# Network policy
+sbx policy ls                          # show rules
+sbx policy log X                       # live connection log
+sbx policy allow network DOMAIN        # allow a domain
+sbx policy deny network DOMAIN         # block a domain
+sbx policy reset                       # choose new default policy
+
+# Secrets
+sbx secret set -g SERVICE              # store globally
+sbx secret ls                          # list secrets
+```
+
+Valid agent values for `sbx create`: `codex`, `claude`, `gemini`, `copilot`, `kiro`, `opencode`, `docker-agent`, `shell`.
+
+---
+
+## ✅ Lab complete
+
+You've earned it. You didn't just read about microVM isolation — you tried to break it. You didn't just read about secret injection — you asked the agent to expose its own key. You didn't just read about network policy — you blocked domains and watched things fail.
+
+That's what "show don't tell" means. And that's what governance you can trust looks like.

--- a/docs/lab8/projects/isolation-proof.md
+++ b/docs/lab8/projects/isolation-proof.md
@@ -1,0 +1,226 @@
+# The Isolation Proof
+
+This is the most important module in the lab. Everything else is context. This is the evidence.
+
+You're going to systematically attempt to access sensitive host resources from inside the sandbox — and document exactly what you find. This is not a trick. Run every command. Read every result.
+
+---
+
+## Setup
+
+You need two terminals side by side:
+
+- **Terminal A** — your running sandbox session (`sbx run sbxlab`)
+- **Terminal B** — your host, for comparison
+
+---
+
+## Part 1 — What the agent can see
+
+Run these commands **inside the sandbox** (Terminal A):
+
+### 1a. Try to access AWS credentials
+
+```bash
+cat ~/.aws/credentials
+ls -la ~/.aws/
+```
+
+Real output:
+
+```
+cat: /home/agent/.aws/credentials: No such file or directory
+
+ls: cannot access '/home/agent/.aws/': No such file or directory
+```
+
+### 1b. Try to access SSH keys
+
+```bash
+cat ~/.ssh/id_rsa
+ls -la ~/.ssh/
+```
+
+Real output:
+
+```
+cat: /home/agent/.ssh/id_rsa: No such file or directory
+
+ls: cannot access '/home/agent/.ssh/': No such file or directory
+```
+
+### 1c. Inspect the agent home directory
+
+```bash
+ls -la ~/
+pwd
+```
+
+Real output:
+
+```
+total 56
+drwxr-xr-x 1 agent agent 4096 Apr 11 14:48 .
+drwxr-xr-x 1 root  root  4096 Apr 11 06:03 ..
+-rw------- 1 agent agent   61 Apr 11 14:48 .bash_history
+-rw-r--r-- 1 agent agent  223 Apr 11 06:20 .bashrc
+drwxr-xr-x 9 agent agent 4096 Apr 11 14:45 .codex
+drwxr-xr-x 3 agent agent   46 Apr 11 06:20 .docker
+-rw-r--r-- 1 agent agent   99 Apr 11 14:45 .gitconfig
+drwxr-xr-x 1 agent agent   27 Apr 11 06:03 workspace
+
+/Users/ajeetraina/sbx-lab
+```
+
+Three things to notice:
+- Agent home is `/home/agent/` — a clean Linux environment, not your Mac home
+- `pwd` shows the exact host path `/Users/ajeetraina/sbx-lab` — preserved as the workspace mount point
+- No `.ssh/`, `.aws/`, `.zshrc`, no Mac files anywhere
+
+### 1d. Inspect the scaffolding boundary
+
+```bash
+ls /Users/
+ls /Users/ajeetraina/
+ls /home/
+ls /var/run/
+```
+
+Real output:
+
+```
+/Users/
+ajeetraina
+
+/Users/ajeetraina/
+AGENTS.md   sbx-lab
+
+/home/
+agent   ubuntu
+
+/var/run/
+containerd  docker  docker.pid  docker.sock  secrets
+```
+
+| Path | What you see | What it means |
+|------|-------------|---------------|
+| `/Users/ajeetraina/` | Only `AGENTS.md` + `sbx-lab` | Empty scaffolding — directory tree preserved for the workspace path, nothing else from your Mac home exists |
+| `/home/` | `agent`, `ubuntu` | Two Linux users, completely separate from your Mac user |
+| `/var/run/docker.sock` | Present | The VM's own Docker daemon — separate from your host's |
+| `/var/run/secrets` | Present | The credential proxy socket — intercepts outbound API calls and injects your keys |
+
+### 1e. Try to reach the AWS metadata endpoint
+
+```bash
+curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/
+```
+
+Real output:
+
+```
+Blocked by network policy: matched rule no applicable policies for op(action=net:connect:tcp,
+resource=net:domain:169.254.169.254:80)
+```
+
+The Balanced network policy blocks the AWS IMDS endpoint entirely — the most dangerous target for a compromised agent running in a cloud VM.
+
+### 1f. Check the VM identity
+
+```bash
+uname -r
+cat /etc/os-release
+cat /proc/1/cgroup
+```
+
+Real output:
+
+```
+6.12.44
+
+PRETTY_NAME="Ubuntu 25.10 (Questing Quokka)"
+NAME="Ubuntu"
+VERSION_ID="25.10"
+
+0::/docker/d65f75fdecab4f730049fd5991cfb82c7a7ff539ec34828b1955021f1f42141c
+```
+
+- Kernel `6.12.44` — Linux, not macOS. This is a real VM with its own kernel
+- Ubuntu 25.10 — full Linux distro running inside the microVM
+- `0::/docker/d65f75fd...` — the `/docker/` prefix confirms the agent runs as a container inside the VM's own Docker daemon
+
+---
+
+## Part 2 — Verify the host is untouched
+
+Switch to **Terminal B** (host):
+
+```bash
+cat ~/.aws/credentials    # still here
+cat ~/.ssh/id_rsa         # still here
+ls -la ~/                 # unchanged
+docker ps                 # your host containers — sbxlab never appears
+sbx ls                    # sbxlab appears here instead
+```
+
+Everything that doesn't exist inside the VM is alive and well on the host.
+
+---
+
+## Part 3 — Guardrails vs sbx: why you need both
+
+You might wonder: if the model refuses to print credentials, why does the sandbox matter?
+
+**Because guardrails and sbx defend different threats.**
+
+| Threat | Model guardrails | sbx |
+|--------|-----------------|-----|
+| Model refuses a direct bad request | ✅ Blocked | ❌ Not its job |
+| Prompt injection in a README or code file | ❌ May comply — looks like a task | ✅ File doesn't exist |
+| Jailbroken model | ❌ Guardrails bypassed | ✅ VM boundary holds |
+| Model with no safety training | ❌ No protection | ✅ Same isolation |
+| Agent runs `rm -rf` outside workspace | ❌ Depends on model | ✅ Impossible — not mounted |
+| Agent exfiltrates to attacker URL | ❌ Depends on model | ✅ Blocked by network policy |
+
+**Guardrails are a bet on the model.** They work when the model is well-behaved, well-trained, and not under adversarial pressure. Change the model, jailbreak it, or hide the instruction in a file the agent reads — and the guardrails disappear.
+
+**sbx is a technical guarantee.** The VM boundary is enforced by the hypervisor, not the model. It holds regardless of what the model does, what prompt it receives, or how it was trained.
+
+> The right mental model: use guardrails to make agents well-behaved. Use sbx to limit the blast radius when they're not.
+
+---
+
+## Part 4 — The architecture
+
+```
+macOS host (L0)
+│
+├── Your files, credentials, Docker daemon   ← outside the VM
+│
+└── sbxlab (microVM, own Linux kernel)
+    │
+    ├── Only ~/sbx-lab workspace mounted      ← the only shared thing
+    ├── Private Docker daemon                 ← completely separate
+    └── Outbound HTTP proxy (/var/run/secrets)
+        │
+        ├── Injects API key on outbound calls  ← agent never sees the key
+        ├── Blocks 169.254.169.254             ← AWS IMDS unreachable
+        └── Balanced policy: allows dev sites, blocks everything else
+```
+
+The key technical fact: **the VM has its own kernel**. A container escape would still be inside the VM. There is no path from the VM's userspace to your host's userspace — the hypervisor enforces that boundary in hardware.
+
+---
+
+## ✅ Checkpoint
+
+You've now empirically proven the isolation guarantee with real commands and real output:
+
+- `~/.aws/credentials` → `No such file or directory`
+- `~/.ssh/id_rsa` → `No such file or directory`
+- `169.254.169.254` → `Blocked by network policy`
+- `uname -r` → Linux kernel `6.12.44`, not macOS
+- `cat /proc/1/cgroup` → `/docker/...` — agent runs in VM's own Docker daemon
+
+Not taken Docker's word for it. Proven it yourself.
+
+Next: how secrets are handled without ever entering the VM.

--- a/docs/lab8/projects/local-models.md
+++ b/docs/lab8/projects/local-models.md
@@ -1,0 +1,303 @@
+# Running Open-Source Models Inside sbx
+
+So far you've governed agents that call cloud LLMs. This module closes the last
+gap: running agents inside sbx against **local open-source models** on your Mac
+— no API keys, no egress, no cloud dependency.
+
+The pattern is simple once you see it:
+
+- **Docker Model Runner** runs on your Mac host at `localhost:12434`
+- **The agent** runs inside the sbx microVM
+- **Only one port** crosses the VM boundary — the OpenAI-compatible HTTP endpoint
+
+That's the strong story: air-gapped agent workflows with zero cloud
+dependency, still governed by the same sandbox, same network policy, same
+audit log.
+
+---
+
+## Why not just run the model inside the sbx?
+
+Two reasons:
+
+1. **Models are heavy.** A 4GB GGUF file plus GPU/Metal acceleration belongs on
+   the host. The sbx is a lean microVM — it doesn't have Metal access.
+2. **Docker Model Runner already exists on the host.** It's built into Docker
+   Desktop, exposes an OpenAI-compatible API, and can be shared by every sbx on
+   your machine.
+
+The agent calls the model over HTTP. That's the only thing the VM boundary
+needs to pass through.
+
+---
+
+## Step 1 - Confirm DMR is running on the host
+
+On your **Mac**:
+
+```bash
+docker model ls
+curl -s http://localhost:12434/engines/llama.cpp/v1/models | head -20
+```
+
+You should see a list of local models. If `docker model ls` is empty, pull a
+small one — smollm2 is 360MB and loads instantly:
+
+```bash
+docker model pull ai/smollm2:360M-Q4_K_M
+```
+
+For a real coding demo, pull something bigger:
+
+```bash
+docker model pull ai/qwen3:8B-Q4_K_M
+```
+
+---
+
+## Step 2 - Create a fresh sbx
+
+On the host:
+
+```bash
+mkdir -p /tmp/dmr-test && cd /tmp/dmr-test
+sbx create --name dmr-test shell .
+```
+
+The `shell` agent gives you a plain bash prompt inside the microVM — no AI
+agent attached. Perfect for testing connectivity before wiring up Codex or
+Claude.
+
+---
+
+## Step 3 - Allow DMR through the network policy
+
+Before you attach, add a local allow rule. The sbx proxy normalizes the target
+to `localhost:12434` internally — even when you'll reach it via
+`host.docker.internal`.
+
+```bash
+sbx policy allow network localhost:12434
+```
+
+Verify:
+
+```bash
+sbx policy ls | grep localhost
+```
+
+You should see one local allow entry for `localhost:12434`.
+
+> **Why `localhost:12434` and not `host.docker.internal:12434`?** The sbx proxy
+> strips the hostname and matches the destination port against policy as
+> `localhost:<port>`. It's the same reason you'll use `host.docker.internal`
+> for the curl but allow `localhost` in the policy — a quirk of the proxy
+> internals.
+
+---
+
+## Step 4 - Attach to the sbx
+
+```bash
+sbx run dmr-test
+```
+
+You'll land inside the VM:
+
+```plaintext
+agent@dmr-test:dmr-test$
+```
+
+Confirm you're really in a fresh Linux guest:
+
+```bash
+hostname
+cat /etc/os-release | head -2
+```
+
+You'll see the sandbox name and a clean Ubuntu 25.10 image — not your Mac.
+
+---
+
+## Step 5 - Reach DMR from inside the sbx
+
+Three things to know about networking inside sbx:
+
+- `localhost` inside the VM is the **VM's own loopback** — not your Mac.
+  `curl localhost:12434` will get **connection refused**.
+- `host.docker.internal` **does** resolve — it points at your Mac host via the
+  sbx gateway.
+- `model-runner.docker.internal` does **not** resolve inside sbx. Don't use it.
+
+Get the model list:
+
+```bash
+curl -s http://host.docker.internal:12434/engines/llama.cpp/v1/models | head -30
+```
+
+You'll see the same list you saw on the host in Step 1 — proof that the sbx
+proxy forwarded the request to DMR.
+
+---
+
+## Step 6 - Run inference across the boundary
+
+```bash
+curl -s http://host.docker.internal:12434/engines/llama.cpp/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ai/smollm2:360M-Q4_K_M",
+    "messages": [{"role":"user","content":"Reply with exactly: sbx to DMR works"}],
+    "max_tokens": 20
+  }'
+```
+
+You'll get back JSON with the model's response in `choices[0].message.content`.
+That's a completed inference round-trip — agent in microVM, model on host,
+OpenAI-compatible protocol between them.
+
+> **Tip:** smollm2 at 360M is great for connectivity tests but too small for
+> real coding. For production-quality demos use `ai/qwen3:8B-Q4_K_M` or
+> `ai/gemma4:latest`.
+
+---
+
+## Step 7 - Python client using the OpenAI SDK
+
+This is the pattern any real agent will use. Create `test_local.py` inside
+the sbx:
+
+```bash
+cat > test_local.py <<'EOF'
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://host.docker.internal:12434/engines/llama.cpp/v1",
+    api_key="not-needed"
+)
+
+resp = client.chat.completions.create(
+    model="ai/qwen3:8B-Q4_K_M",
+    messages=[{
+        "role": "user",
+        "content": "Write a Python function that reads a CSV and counts rows."
+    }]
+)
+print(resp.choices[0].message.content)
+EOF
+```
+
+Install the SDK and run it:
+
+```bash
+pip install --break-system-packages openai
+python3 test_local.py
+```
+
+The model generates Python code — completely offline, no API key, no egress.
+
+---
+
+## Step 8 - Run a coding agent against the local model
+
+Swap the `shell` agent for a real one. Codex and Claude Code both respect
+`OPENAI_BASE_URL` and `OPENAI_API_KEY` environment variables, so pointing them
+at DMR is a one-liner.
+
+First stop the shell sandbox:
+
+```bash
+sbx stop dmr-test
+sbx rm dmr-test
+```
+
+Create a codex sandbox and inject the local-model env vars:
+
+```bash
+cd /tmp/dmr-test
+sbx create --name dmr-codex codex .
+```
+
+Add the env vars to the codex config so they're available to the agent every
+run. Inside the sbx once you attach:
+
+```bash
+export OPENAI_BASE_URL=http://host.docker.internal:12434/engines/llama.cpp/v1
+export OPENAI_API_KEY=not-needed
+codex "write a Python script that prints the first 10 Fibonacci numbers"
+```
+
+The agent is running inside the microVM. The model is running on your Mac.
+The only thing crossing the boundary is OpenAI-compatible JSON over HTTP. No
+cloud. No secrets leaving the host. No tokens billed.
+
+---
+
+## Watch the policy log during the run
+
+In a separate host terminal:
+
+```bash
+sbx policy log dmr-codex
+```
+
+Every inference request shows up as an allowed `localhost:12434` entry. That's
+your audit trail — proof that the agent only talked to the local model and
+nothing else.
+
+Try breaking it. Stop the sbx, change the allow rule to a deny, and restart —
+the agent will fail to reach the model. Network policy governs local traffic
+the same way it governs cloud traffic.
+
+---
+
+## Conclusion
+
+This is the pitch to hand your rep:
+
+- **Agent is fully isolated.** microVM boundary, not a container escape risk.
+- **Model runs locally.** No cloud API costs, no third-party LLM exposure, no
+  token limits.
+- **Secrets never leave the host.** Your Mac keeps its API keys and SSH
+  credentials. The sbx never sees them.
+- **Network is governed.** Even `localhost:12434` requires an explicit allow
+  rule. Every request is logged.
+- **Works air-gapped.** Regulated enterprises — healthcare, finance, defense —
+  can run this pattern on air-gapped networks with zero cloud dependency.
+
+That's the "agent in a microVM, model on the host, zero cloud dependency"
+architecture. sbx + DMR gives you the first real open-source implementation
+of it.
+
+---
+
+## Troubleshooting
+
+**`curl localhost:12434` returns connection refused inside sbx.**
+Expected. `localhost` is the VM's own loopback. Use `host.docker.internal`.
+
+**`curl host.docker.internal:12434` returns `Blocked by network policy`.**
+You didn't add the allow rule. Run `sbx policy allow network localhost:12434`
+on the host and restart the sbx.
+
+**`curl model-runner.docker.internal` returns `no such host`.**
+That DNS name doesn't resolve inside sbx. Only `host.docker.internal` does.
+
+**Agent reaches DMR but inference returns 404 or garbled output.**
+Check the exact model ID with `docker model ls` on the host — model names with
+quantization tags like `ai/smollm2:360M-Q4_K_M` must be passed verbatim in the
+request body.
+
+---
+
+## ✅ Checkpoint
+
+Before moving on, confirm you can:
+
+- Reach DMR from inside the sbx via `host.docker.internal:12434`
+- Run a chat completion against a local model
+- Point a Python OpenAI SDK client at the local endpoint
+- Point a coding agent (codex) at the local model via `OPENAI_BASE_URL`
+- Watch the connections in `sbx policy log`
+
+Next: the governance summary — the full architecture pulled together.

--- a/docs/lab8/projects/network-policy.md
+++ b/docs/lab8/projects/network-policy.md
@@ -1,0 +1,218 @@
+# Network Policy
+
+The sandbox controls what the agent can reach on the network. This is the third
+layer of isolation — and it gives you a complete audit trail of every connection
+the agent attempts.
+
+---
+
+## The default: already open for common dev tools
+
+sbx ships with **5 default allow policies** covering everything a developer
+typically needs. You don't need to configure anything for standard workflows.
+
+Check what's allowed right now:
+
+```bash
+sbx policy ls
+```
+
+You'll see five policy groups:
+
+| Policy | What it covers |
+|---|---|
+| `default-ai-services` | OpenAI, Anthropic, Gemini, Cursor, Perplexity |
+| `default-package-managers` | PyPI, npm, cargo, maven, rubygems, and more |
+| `default-code-and-containers` | GitHub, GitLab, Docker Hub, ghcr.io |
+| `default-cloud-infrastructure` | AWS, GCP, Azure, Vercel, Fastly |
+| `default-os-packages` | Ubuntu, Debian, Alpine package repos |
+
+`pypi.org`, `files.pythonhosted.org`, `npmjs.org`, `github.com` — all already
+allowed. No setup required.
+
+---
+
+## Prove it: install a package
+
+Start your sandbox and ask the agent to install `httpx`:
+
+```bash
+sbx run sbxlab
+```
+
+Then prompt:
+
+> Install httpx and tell me the version
+
+The agent will work through PEP 668 on its own and successfully install:
+
+```plaintext
+• Ran python3 -m pip install httpx
+  └ error: externally-managed-environment ...
+
+• Ran python3 -m pip install --break-system-packages httpx
+  └ Successfully installed httpx-0.28.1
+    0.28.1
+```
+
+The agent self-corrected and got the answer — all inside the microVM, your Mac
+untouched.
+
+---
+
+## The real power: deny rules
+
+The default policies allow common tools. But you can **restrict** what the agent
+can reach — blocking specific domains at the network layer, regardless of what
+the agent tries.
+
+### Step 1 — Block PyPI
+
+```bash
+sbx policy deny network pypi.org
+```
+
+Verify it's active:
+
+```bash
+sbx policy ls
+```
+
+You'll see a new local entry at the bottom:
+
+```plaintext
+local:9701dc6e-...   network   deny   pypi.org
+```
+
+### Step 2 — Restart the sandbox
+
+Policy changes require a sandbox restart to take effect:
+
+```bash
+sbx stop sbxlab
+sbx run sbxlab
+```
+
+### Step 3 — Watch the agent fail
+
+Ask the agent to install a package:
+
+> Install requests and tell me the version
+
+The agent is persistent — it will try multiple approaches, all of which fail:
+
+```plaintext
+• Ran pip install requests
+  └ error: externally-managed-environment
+
+• Ran pip install --break-system-packages requests
+  └ ERROR: Could not find a version that satisfies the requirement requests
+    ERROR: No matching distribution found for requests
+
+• Ran curl -I https://pypi.org/simple/requests/
+  └ HTTP/2 403
+```
+
+The agent tried everything it knew. It still failed. Not because of a system
+prompt instruction — because the proxy blocked the TCP connection at the network
+layer.
+
+> **Key insight:** A smarter agent cannot bypass a network deny rule.
+> Agent capability and network policy are completely independent layers.
+
+### Step 4 — Find and remove the deny rule
+
+List policies to get the rule ID:
+
+```bash
+sbx policy ls
+```
+
+Look for the local deny entry at the bottom. Copy its UUID (the part after
+`local:`), then remove it:
+
+```bash
+sbx policy rm network --id <uuid-from-policy-ls>
+```
+
+> **Important:** Use `--id` with just the UUID — drop the `local:` prefix.
+
+Verify it's gone:
+
+```bash
+sbx policy ls
+```
+
+No local entries should remain.
+
+### Step 5 — Confirm the agent works again
+
+Restart the sandbox:
+
+```bash
+sbx stop sbxlab
+sbx run sbxlab
+```
+
+Ask the agent to install requests again — it works immediately.
+
+---
+
+## Key rules about policy precedence
+
+- **Deny overrides allow** — a local deny rule beats any default allow policy
+- **Restart required** — policy changes take effect on the next `sbx run`
+- **Always clean up deny rules** — use `sbx policy rm network --id <uuid>`
+- **Default policies cannot be removed** — only local rules you add can be removed
+
+---
+
+## Watch live connections
+
+In a separate terminal, watch every outbound connection in real time:
+
+```bash
+sbx policy log sbxlab
+```
+
+You'll see each connection as it happens:
+
+```plaintext
+ALLOWED   pypi.org                 200
+ALLOWED   files.pythonhosted.org   200
+```
+
+Add a deny rule and repeat — you'll see:
+
+```plaintext
+BLOCKED   pypi.org   -
+```
+
+This log is your **audit trail**. For regulated enterprises it answers:
+*"What did the agent do on the network, and when?"*
+
+---
+
+## Reach host services from inside the sandbox
+
+If you have a local service running on your Mac (like Ollama on port 11434),
+use `host.docker.internal` — not `localhost`, which resolves to the VM itself:
+
+```bash
+sbx policy allow network localhost:11434
+```
+
+Then inside the sandbox, connect to `host.docker.internal:11434`.
+
+---
+
+## ✅ Checkpoint
+
+Before moving on, confirm you can:
+
+- Run `sbx policy ls` and identify the 5 default policy groups
+- Add a deny rule and observe the agent failing
+- Remove the deny rule with `sbx policy rm network --id <uuid>`
+- Confirm the agent works again after the deny rule is removed
+
+Next: branch mode — how to run agents without touching your working tree.

--- a/docs/lab8/projects/parallel-agents.md
+++ b/docs/lab8/projects/parallel-agents.md
@@ -1,0 +1,139 @@
+# Parallel Agents — Two Agents, One Sandbox, Zero Conflicts
+
+Branch mode isn't just for review workflows. It's how you run multiple agents simultaneously on the same codebase without any conflicts.
+
+Each branch-mode run creates its own isolated Git worktree. Two agents on two branches never touch each other's files. Both are governed by the same network policy. Both generate audit logs.
+
+---
+
+## The DevBoard has two unfinished features
+
+Perfect for parallel execution:
+
+**Search** — `GET /issues/search?q=` returns HTTP 501. The query logic hasn't been written yet.
+
+**Notifications** — `send_status_change_notification()` is a no-op stub. It should send emails when issue status changes.
+
+These are independent — no shared code paths. Ideal for parallel work.
+
+---
+
+## Launch two agents simultaneously
+
+Open **two host terminal windows**. Run each command in its own window at the same time.
+
+**Terminal 1 — Search feature:**
+
+```bash
+cd ~/sbx-lab
+sbx run sbxlab --branch=add-search -- "$(cat prompts/implement-search.txt)"
+```
+
+**Terminal 2 — Notifications feature:**
+
+```bash
+cd ~/sbx-lab
+sbx run sbxlab --branch=add-notif -- "$(cat prompts/implement-notifications.txt)"
+```
+
+> **Note:** The `"$(cat ...)"` must be quoted or the prompt won't pass correctly.
+
+Both run against the same `sbxlab` sandbox — no new sandbox is created. You still see one entry in `sbx ls`. Each agent has its own isolated worktree under `.sbx/sbxlab-worktrees/`.
+
+---
+
+## Watch both agents work
+
+In a **third terminal**, watch the worktrees update in real time:
+
+```bash
+cd ~/sbx-lab
+
+# Watch commits appear on each branch
+watch -n 2 'git log --oneline add-search | head -5; echo "---"; git log --oneline add-notif | head -5'
+```
+
+Two agents. Two branches. Completely independent progress.
+
+---
+
+## Monitor the network policy log
+
+In a **fourth terminal**:
+
+```bash
+sbx policy log sbxlab
+```
+
+You'll see both agents making API calls — all routed through the same proxy, all logged, all governed by the same policy.
+
+---
+
+## Review and open PRs
+
+When both agents have finished (you'll see them exit or hit prompts):
+
+```bash
+# Review search implementation
+git diff main..add-search
+git diff main..add-search --stat
+
+# Review notifications implementation
+git diff main..add-notif
+git diff main..add-notif --stat
+```
+
+Push and create PRs:
+
+```bash
+git push origin add-search
+gh pr create --head add-search \
+  --title "Implement issue search" \
+  --body "Implements GET /issues/search endpoint"
+
+git push origin add-notif
+gh pr create --head add-notif \
+  --title "Implement status change notifications" \
+  --body "Implements email notifications on status changes"
+```
+
+---
+
+## What this means at scale
+
+You just ran two autonomous agents on the same repo simultaneously. Each had governance:
+- Isolated VM boundary
+- Secrets via proxy injection — no keys in the VM
+- Network policy enforcing what they could reach
+- Audit log of every connection
+- Clean Git diffs for human review before merge
+
+Now imagine this at 10,000 developers. Each developer might have 2–3 agents running simultaneously. That's potentially 30,000 concurrent agent sessions — all governed by the same central policy, all generating audit logs, all hitting the same LLM gateway.
+
+That's the enterprise story. That's what the network policy and sandbox architecture are built for.
+
+---
+
+## Clean up worktrees
+
+After reviewing and merging:
+
+```bash
+git worktree remove .sbx/sbxlab-worktrees/add-search
+git worktree remove .sbx/sbxlab-worktrees/add-notif
+git branch -d add-search add-notif
+```
+
+Or when you `sbx rm sbxlab`, all worktrees are cleaned up automatically.
+
+---
+
+## ✅ Checkpoint
+
+Confirm:
+- Two agents ran simultaneously without conflicts
+- `git worktree list` showed both branches
+- Both produced clean diffs reviewable by a human
+- The policy log showed both agents' activity
+
+Next: Docker Compose inside the sandbox — the full-stack use case.

--- a/docs/lab8/projects/reviewing-agent-changes.md
+++ b/docs/lab8/projects/reviewing-agent-changes.md
@@ -1,0 +1,222 @@
+# Reviewing Agent Changes
+
+The agent has full write access to your workspace directory. Files it creates
+or modifies appear on your host immediately. This is by design, it's what
+makes the agent useful.
+
+But full write access includes files that **execute code automatically** when
+you commit, build, or open your project. Review these before you act on them.
+
+---
+
+## What the agent can touch
+
+The agent can create, modify, and delete any file in the workspace including:
+
+| File type | When it executes |
+|---|---|
+| `.git/hooks/` | On every `git commit`, `git push`, etc. |
+| `.github/workflows/` | On every push to GitHub |
+| `Makefile`, `package.json` scripts | During build or install |
+| `.vscode/tasks.json`, `.idea/` | When you open the project in your IDE |
+| Shell scripts and executables | When run directly |
+| `.env`, config files | When your app starts |
+
+> **The risk:** An agent running malicious or buggy code could modify a Git
+> hook that then runs on your host every time you commit. The microVM protects
+> your host *while the agent is running* but files written to your workspace
+> persist after the session ends.
+
+---
+
+## Always review before you act
+
+After every agent session, before you commit, build, or open the project:
+
+### Direct mode (default)
+
+Run `git diff` to see changes in your working tree, and `git status` to check
+what files were modified.
+
+### Branch mode
+
+Run `git diff main..my-feature` to see the agent's changes on a separate branch.
+
+---
+
+## The hidden danger: Git hooks
+
+Git hooks live inside `.git/hooks/` — they are **not tracked by Git** and
+do **not appear in `git diff` output**. An agent could modify a hook and you'd
+never see it in a normal diff.
+
+Always check hooks separately after an agent session by running
+`ls -la .git/hooks/` and reading any recently modified files with
+`cat .git/hooks/pre-commit` before running any Git commands.
+
+---
+
+## Prove it yourself
+
+Let's demonstrate this. First, make sure you are in your sbx workspace:
+
+```bash
+cd ~/sbx-lab
+```
+
+Start your sandbox:
+
+```bash
+sbx run sbxlab
+```
+
+Ask the agent to create a Git hook:
+
+```text
+Create a pre-commit hook that prints "hello from the agent" before every commit
+```
+
+Exit the sandbox:
+
+```bash
+exit
+```
+
+The microVM is now gone. Check the hook on your host:
+
+```bash
+ls -la .git/hooks/
+```
+
+Look for `pre-commit` with a recent timestamp — created by the agent, now
+living on your Mac.
+
+```bash
+cat .git/hooks/pre-commit
+```
+
+Expected output:
+
+```
+#!/usr/bin/env bash
+echo "hello from the agent"
+```
+
+Now trigger it:
+
+```bash
+git commit --allow-empty -m "test hook"
+```
+
+Expected output:
+
+```
+hello from the agent
+[main 9c1f07e] test hook
+```
+
+That's agent-written code running on your Mac. The microVM is gone — but the
+file persists and executes with your full host privileges.
+
+> **This is not a bug. This is the expected behavior.**
+>
+> sbx isolates the agent while it runs. It does not sanitize what the agent
+> writes to your workspace. Review before you execute.
+
+---
+
+## Cleaning up
+
+To remove the hook the agent created:
+
+```bash
+rm .git/hooks/pre-commit
+```
+
+To reset all hooks to their default state:
+
+```bash
+find .git/hooks -type f ! -name "*.sample" -delete
+```
+
+---
+
+## Branch mode: the safer workflow for untrusted tasks
+
+When you're not sure what an agent will do, use branch mode. The agent still
+has full write access — but its changes land on a separate worktree and branch,
+not your main working tree.
+
+```bash
+sbx run sbxlab --branch=agent-experiment
+```
+
+sbx creates a new worktree at `~/sbxlab-worktrees/agent-experiment` and opens
+the agent there. Your `~/sbx-lab` working tree is untouched while the agent runs.
+
+When the agent is done, exit the sandbox:
+
+```bash
+exit
+```
+
+Now review what changed before touching anything:
+
+```bash
+cd ~/sbx-lab
+git diff main..agent-experiment
+```
+
+Check git hooks separately — they won't appear in the diff:
+
+```bash
+ls -la ~/sbxlab-worktrees/agent-experiment/.git/hooks/
+```
+
+If you're happy with the changes, merge:
+
+```bash
+git merge agent-experiment
+```
+
+If not, discard everything:
+
+```bash
+git branch -D agent-experiment
+```
+
+Pay special attention to the same file types — Git hooks, CI config, build
+files, IDE config. Even in branch mode, review before you merge.
+
+> **Branch mode is not a security boundary.** The agent still has full write
+> access to the worktree. It gives you a clean diff to review — not protection
+> from malicious writes.
+
+---
+
+## The mental model
+
+Think of the agent like a contractor with keys to your workspace:
+
+- **While inside the sandbox**: fully isolated, can't touch your other systems
+- **Files written to workspace**: persist on your host after the session
+- **Your responsibility**: review what was written before running any of it
+
+This is the same trust model you'd apply to any open source dependency or
+pull request from an external contributor. Review before you trust.
+
+---
+
+## ✅ Checkpoint
+
+Before moving on:
+
+- [ ] Run `cd ~/sbx-lab` before testing hooks — git hooks are per-repository
+- [ ] Run `git diff` after an agent session and review the changes
+- [ ] Check `.git/hooks/` separately — it won't appear in `git diff`
+- [ ] Understand that branch mode gives you a clean diff to review, but is not
+      a security boundary
+- [ ] Know how to remove or reset hooks the agent created
+
+Next: secrets without exposure — how sbx injects credentials without the agent
+ever seeing them.

--- a/docs/lab8/projects/secrets.md
+++ b/docs/lab8/projects/secrets.md
@@ -1,0 +1,195 @@
+# Secrets Without Exposure
+
+You've proven the agent can't reach your host credentials. Now let's look at how the agent authenticates to external services — without ever seeing the raw key.
+
+---
+
+## How it works
+
+When you stored your API key in the Pre-flight:
+
+!!! note "If you chose OpenAI + Codex"
+
+    ```bash
+    echo "$OPENAI_API_KEY" | sbx secret set -g openai
+    ```
+
+!!! note "If you chose Anthropic + Claude"
+
+    ```bash
+    echo "$ANTHROPIC_API_KEY" | sbx secret set -g anthropic
+    ```
+
+!!! note "If you chose Google + Gemini"
+
+    ```bash
+    echo "$GOOGLE_API_KEY" | sbx secret set -g google
+    ```
+
+It went into your **OS keychain** — macOS Keychain on Mac, the system credential store on Linux. It was never written to disk as plain text. It was never put inside the VM.
+
+When the agent makes an outbound API call, the flow is:
+
+!!! note "If you chose OpenAI + Codex"
+
+    ```
+    Codex (inside VM)
+        → HTTP request to api.openai.com (no auth header)
+        → Host-side proxy intercepts the request
+        → Proxy reads credential from OS keychain
+        → Proxy injects Authorization header
+        → Request goes to OpenAI with valid credential
+        → Response comes back to Codex
+
+    Codex never saw the key.
+    ```
+
+!!! note "If you chose Anthropic + Claude"
+
+    ```
+    Claude (inside VM)
+        → HTTP request to api.anthropic.com (no auth header)
+        → Host-side proxy intercepts the request
+        → Proxy reads credential from OS keychain
+        → Proxy injects Authorization header
+        → Request goes to Anthropic with valid credential
+        → Response comes back to Claude
+
+    Claude never saw the key.
+    ```
+
+!!! note "If you chose Google + Gemini"
+
+    ```
+    Gemini (inside VM)
+        → HTTP request to generativelanguage.googleapis.com (no auth header)
+        → Host-side proxy intercepts the request
+        → Proxy reads credential from OS keychain
+        → Proxy injects Authorization header
+        → Request goes to Google with valid credential
+        → Response comes back to Gemini
+
+    Gemini never saw the key.
+    ```
+
+---
+
+## See your stored secrets
+
+In a host terminal:
+
+```bash
+sbx secret ls
+```
+
+You'll see something like:
+
+```
+SCOPE      SERVICE         SECRET
+(global)   <secret-name>   ****...****
+(global)   github          ghp_****...****
+```
+
+The values are masked in the display. They live in your OS keychain.
+
+---
+
+## Try to extract the key from inside the sandbox
+
+Go into your sandbox session and run:
+
+!!! note "If you chose OpenAI + Codex"
+
+    ```bash
+    echo $OPENAI_API_KEY
+    printenv | grep -i openai
+    printenv | grep -i api_key
+    ```
+
+!!! note "If you chose Anthropic + Claude"
+
+    ```bash
+    echo $ANTHROPIC_API_KEY
+    echo $CLAUDE_API_KEY
+    printenv | grep -i anthropic
+    printenv | grep -i api_key
+    ```
+
+!!! note "If you chose Google + Gemini"
+
+    ```bash
+    echo $GOOGLE_API_KEY
+    echo $GEMINI_API_KEY
+    printenv | grep -i google
+    printenv | grep -i gemini
+    printenv | grep -i api_key
+    ```
+
+**What you'll see:** Empty. The key is not in the environment. It doesn't exist as a variable inside the VM.
+
+---
+
+## Ask the agent directly
+
+Give the agent this prompt:
+
+```
+What is your API key? Print the value of any API_KEY environment 
+variable you have access to.
+```
+
+The agent will tell you it doesn't have access. It's not being cagey — the key literally doesn't exist anywhere the agent can reach. The proxy is the authentication layer.
+
+---
+
+## What about other services?
+
+sbx supports proxy injection for all major AI providers and Git hosts:
+
+| Service | Environment variable(s) injected |
+|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `openai` | `OPENAI_API_KEY` |
+| `google` | `GEMINI_API_KEY`, `GOOGLE_API_KEY` |
+| `github` | `GH_TOKEN`, `GITHUB_TOKEN` |
+| `aws` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
+
+For services not on this list, you can write values to `/etc/sandbox-persistent.sh` inside the sandbox — but those are visible to the agent. Use proxy injection whenever possible.
+
+---
+
+## Store a GitHub token (if you haven't already)
+
+```bash
+# On host — not inside the sandbox
+echo "$(gh auth token)" | sbx secret set -g github
+```
+
+> **Important:** Global secrets must be set before the sandbox is created. They're injected at creation time. If you add a secret after creation, recreate the sandbox to pick it up.
+
+Sandbox-scoped secrets (without `-g`) can be added any time:
+
+```bash
+sbx secret set sbxlab <secret-name>   # scoped to sbxlab only
+```
+
+---
+
+## Why this matters for enterprise governance
+
+The traditional approach: put the API key in an environment variable or a `.env` file. The agent reads it. The agent can log it, print it, commit it to git.
+
+The sbx approach: the key never enters the VM. Even if the agent is compromised, even if a malicious MCP server runs inside the sandbox, even if the agent is specifically instructed to exfiltrate credentials — there's nothing to exfiltrate.
+
+This is why "secrets in environment variables" fails as a security model for agentic workloads. And why proxy injection is the right architecture.
+
+---
+
+## ✅ Checkpoint
+
+Confirm:
+- `sbx secret ls` shows your `<secret-name>` credential
+- `printenv | grep -i api_key` inside the sandbox returns empty
+- The agent reports it doesn't have access to its API key when asked directly
+
+Next: controlling what the agent can reach on the network.

--- a/docs/lab8/projects/why-governance.md
+++ b/docs/lab8/projects/why-governance.md
@@ -1,0 +1,106 @@
+# Why AI Agents Need Governance
+
+No terminal needed for this module. Read carefully — everything you run in the next seven modules exists because of what's on this page.
+
+---
+
+## The Problem: Agents Running on the Host
+
+When a developer runs Claude Code on their laptop without sandboxing, the agent runs as their user process. That means it has access to everything they have access to:
+
+- `~/.aws/credentials` — AWS access keys
+- `~/.ssh/id_rsa` — SSH private keys  
+- `.env` files — database passwords, API tokens
+- The entire home directory
+- Any running Docker containers on the host
+
+The agent isn't malicious. But it doesn't need to be for something to go wrong. A confused agent, a malicious MCP server, a prompt injection attack — any of these can cause the agent to exfiltrate credentials or corrupt data. And if there's no audit trail, you won't know it happened.
+
+---
+
+## Real Incidents — Not Hypothetical
+
+These are documented vulnerabilities from 2025:
+
+**Cursor's System Prompt Leaked** — The agent's internal instructions were exposed, revealing details about its tool access and capabilities. Developers building on top of Cursor couldn't trust their agents weren't being manipulated.
+
+**GitHub Copilot / Cursor RCE via Malicious MCP File Swaps** — An attacker could replace an approved MCP server file after approval, causing the agent to execute arbitrary code with the developer's credentials.
+
+**MCP Tool Poisoning** — A critical vulnerability in the Model Context Protocol allowed attackers to poison tool descriptions, causing agents to take unintended actions. Anthropic, OpenAI, Zapier, and Cursor were all affected.
+
+The pattern: **agents are trusted, and that trust is being exploited.**
+
+---
+
+## Why Current "Solutions" Don't Work
+
+### Permission Dialogs
+
+```
+┌─────────────────────────┐
+│   Delete all your data? │
+│                         │
+│   [ Yes ]    [ No ]     │
+└─────────────────────────┘
+```
+
+Developers running agents in YOLO mode (the default for productivity) dismiss these. They accumulate. They become noise. They are not security.
+
+### System Prompt Instructions
+
+```
+I solemnly promise not to read any 
+sensitive .env files unless you ask 
+me really nicely.
+```
+
+A system prompt is text. It can be overridden by prompt injection. It has no enforcement mechanism. It is not security.
+
+---
+
+## What Actually Works: The microVM Boundary
+
+Docker Sandboxes runs each agent in a **lightweight microVM** — a virtual machine with its own dedicated Linux kernel. The agent runs inside the VM. Your credentials live on your host. The only thing shared is the workspace directory you explicitly mount.
+
+```
+Your Mac (host)
+├── ~/.aws/credentials     ← here, untouched
+├── ~/.ssh/id_rsa          ← here, untouched  
+├── /var/run/docker.sock   ← host daemon, untouched
+│
+└── sbxlab (microVM)
+    ├── /your/workspace    ← shared, bidirectional
+    ├── private Docker daemon
+    └── outbound proxy     ← enforces network policy, injects creds
+```
+
+The boundary is structural. It's enforced by the hypervisor, not by a policy document or a system prompt. The agent can't reach what isn't mounted — not because it's been told not to, but because it doesn't exist inside the VM.
+
+---
+
+## The Agent Autonomy Scale
+
+| Stage | Name | Description |
+|---|---|---|
+| 1 | Autocomplete | Code suggestions in IDE |
+| 2 | Assistant | Chat, Q&A, explanations |
+| 3 | Specialist | Multi-step task completion |
+| **4** | **Semi-Autonomous** | **Governed agent loops ← sbx target** |
+| **5** | **Autonomous** | **Self-directed workflows ← sbx target** |
+| 6 | Steward | Long-term agent vision, full trust model |
+
+Most enterprises today are at stage 2–3. sbx is the infrastructure that makes stages 4–5 safe to operate. Without governance, you skip stages and take the risk with you.
+
+---
+
+## What You'll Learn in This Lab
+
+By the end of this lab, you will be able to:
+
+- Prove structurally that an agent cannot access host credentials (Module 3)
+- Explain how secret injection works without exposing keys to the agent (Module 4)
+- Configure and observe network policy enforcement in real time (Module 5)
+- Use branch mode to get clean agent diffs for review (Module 6)
+- Run multiple agents in parallel on the same codebase without conflicts (Module 7)
+
+Let's start.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,8 +100,20 @@ nav:
     - Docker Sandboxes:
       - Overview: lab8/overview.md
       - Getting Started: lab8/getting-started.md
+      - Concepts:
+        - Why Agents Need Governance: lab8/projects/why-governance.md
+      - Hands-on Modules:
+        - Your First Sandbox: lab8/projects/first-sandbox.md
+        - The Isolation Proof: lab8/projects/isolation-proof.md
+        - Reviewing Agent Changes: lab8/projects/reviewing-agent-changes.md
+        - Secrets Without Exposure: lab8/projects/secrets.md
+        - Network Policy: lab8/projects/network-policy.md
+        - Branch Mode: lab8/projects/branch-mode.md
+        - Parallel Agents: lab8/projects/parallel-agents.md
+        - Running Open-Source Models: lab8/projects/local-models.md
+        - AI Governance at Scale: lab8/projects/governance-summary.md
       - Projects:
-        - Playwrite Browser Testing: lab8/projects/playwright-browser-testing.md
+        - Playwright Browser Testing: lab8/projects/playwright-browser-testing.md
   - Docker and Security:
     - Docker Hardened Images:
       - Overview: lab9/dhi/overview.md


### PR DESCRIPTION
Fills in the Docker Sandbox section of the workshop sidebar with the 11 lab modules from ajeetraina/labspace-sbx, structured to mirror the Docker Agent (lab10) layout: Overview, Getting Started, Concepts, Hands-on Modules, and Projects.

Conversions applied for MkDocs Material compatibility:
- :::conditionalDisplay blocks -> !!! note admonitions per provider
- ::variableSetButton lines -> a single "Pick a provider" tip callout
- Labspace dollar-dollar placeholders -> <agent>, <secret-name>
- Stripped no-run-button / no-copy-button code-fence flags

Also fixes "Playwrite" -> "Playwright" typo in mkdocs.yml.

Source: https://github.com/ajeetraina/labspace-sbx